### PR TITLE
Version check removal/broader DefenseShields API activation

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -1211,7 +1211,7 @@ namespace CoreSystems
                     ModInfo.TryAdd(mod.GetPath(), mod);
 
                 if (mod.PublishedFileId == 1365616918 || mod.PublishedFileId == 2372872458) ShieldMod = true;
-                else if (mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\DefenseShields"))
+                else if (mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\DefenseShields") || mod.Name.StartsWith("DefenseShields") || mod.FriendlyName.StartsWith("DefenseShields"))
                     ShieldMod = true;
                 else if (mod.PublishedFileId == 1931509062 || mod.PublishedFileId == 1995197719 || mod.PublishedFileId == 2006751214 || mod.PublishedFileId == 2015560129)
                     ReplaceVanilla = true;

--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -1225,7 +1225,7 @@ namespace CoreSystems
                     WaterMod = true;
             }
 
-            SuppressWc = !SUtils.ModActivate(ModContext, Session);
+            //SuppressWc = !SUtils.ModActivate(ModContext, Session);
 
             if (!SuppressWc && !ReplaceVanilla)
             {

--- a/Data/Scripts/CoreSystems/Support/StaticUtils.cs
+++ b/Data/Scripts/CoreSystems/Support/StaticUtils.cs
@@ -16,6 +16,7 @@ namespace CoreSystems.Support
 {
     internal static class SUtils
     {
+        /*
         public static bool ModActivate(IMyModContext context, IMySession session)
         {
             var priority1 = 2734980390ul;
@@ -62,7 +63,7 @@ namespace CoreSystems.Support
             var validP3 = isP3 && (!p0Exists && !p1Exists && !p2Exists);
             return validP3;
         }
-
+          */
         public static void GetFourInt16FromLong(long id, out int w, out int x, out int y, out int z)
         {
 


### PR DESCRIPTION
- comments out modactivate 
- lets shield mods with different steam workshopIDs get recognized, as long as they are prefixed with DefenseShields
fixes #2 