### PR TITLE
PD targeting respects Neutrals option

### DIFF
--- a/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
@@ -23,8 +23,11 @@ namespace CoreSystems.Support
                     return;
 
                 if (AiType == AiTypes.Grid) {
+                    var oldOwner = AiOwner;
                     var bigOwners = GridEntity.BigOwners;
                     AiOwner = bigOwners.Count > 0 ? bigOwners[0] : 0;
+                    if (oldOwner != AiOwner)
+                        UpdateFactionColors();
                 }
             }
 

--- a/Data/Scripts/CoreSystems/Ai/AiFields.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiFields.cs
@@ -120,6 +120,7 @@ namespace CoreSystems.Support
         internal BoundingBox BlockChangeArea = BoundingBox.CreateInvalid();
         internal AiTypes AiType;
         internal long AiOwner;
+        internal long AiOwnerFactionId;
         internal bool IsBot;
         internal bool EnemyProjectiles;
         internal bool EnemyEntities;

--- a/Data/Scripts/CoreSystems/Ai/AiSupport.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiSupport.cs
@@ -54,10 +54,14 @@ namespace CoreSystems.Support
                                 return;
                             }
 
+                            var wCompMaxWepRange = wComp.MaxDetectDistance;
                             WeaponComps.RemoveAtFast(weaponIdx);
                             if (weaponIdx < WeaponComps.Count)
                                 WeaponIdx[WeaponComps[weaponIdx]] = weaponIdx;
                             WeaponIdx.Remove(wComp);
+
+                            if (wCompMaxWepRange >= (MaxTargetingRange - TopEntity.PositionComp.LocalVolume.Radius) * 0.95) //Filter so that only the longest ranged weps force a recalc
+                                UpdateMaxTargetingRange();
 
                             if (wComp.Data.Repo.Values.Set.Overrides.WeaponGroupId > 0)
                                 CompWeaponGroups.Remove(wComp);
@@ -190,6 +194,23 @@ namespace CoreSystems.Support
                     }
                     break;
             }
+        }
+
+        private void UpdateMaxTargetingRange()
+        {
+            var longestRange = 0d;
+            foreach(var wComp in WeaponComps)
+            {
+                if (wComp.MaxDetectDistance > longestRange)
+                {
+                    longestRange = wComp.MaxDetectDistance;
+                    if (longestRange >= Session.I.Settings.Enforcement.MaxHudFocusDistance)
+                        break;
+                }
+            }
+            var expandedMaxTrajectory = longestRange + TopEntity.PositionComp.LocalVolume.Radius;
+            MaxTargetingRange = MathHelperD.Min(expandedMaxTrajectory, Session.I.Settings.Enforcement.MaxHudFocusDistance);
+            MaxTargetingRangeSqr = MaxTargetingRange * MaxTargetingRange;            
         }
 
         private static int[] GetDeck(ref int[] deck, int firstCard, int cardsToSort, int cardsToShuffle, ref XorShiftRandomStruct rng)

--- a/Data/Scripts/CoreSystems/Ai/AiSupport.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiSupport.cs
@@ -435,17 +435,20 @@ namespace CoreSystems.Support
                     FgFactionColor = MyColorPickerConstants.HSVOffsetToHSV(aiFaction.IconColor).HSVtoColor().ToVector4().ToLinearRGB();
                     FgFactionColor *= 100;
                     FgFactionColor.W *= 0.01f;
+                    AiOwnerFactionId = aiFaction.FactionId;
                 }
                 else
                 {
                     BgFactionColor = Vector4.Zero;
                     FgFactionColor = Vector4.Zero;
+                    AiOwnerFactionId = 0;
                 }
             }
             else
             {
                 BgFactionColor = Vector4.Zero;
                 FgFactionColor = Vector4.Zero;
+                AiOwnerFactionId = 0;
             }
         }
 
@@ -510,6 +513,7 @@ namespace CoreSystems.Support
             SourceCount = 0;
             PartCount = 0;
             AiOwner = 0;
+            AiOwnerFactionId = 0;
             LastAddToRotorTick = 0;
             ProjectileTicker = 0;
             NearByEntities = 0;

--- a/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
@@ -18,6 +18,7 @@ using static CoreSystems.Support.WeaponDefinition.AmmoDef;
 using static CoreSystems.Platform.Weapon.ApiShootRequest;
 using IMyWarhead = Sandbox.ModAPI.IMyWarhead;
 using CollisionLayers = Sandbox.Engine.Physics.MyPhysics.CollisionLayers;
+using Sandbox.ModAPI;
 
 namespace CoreSystems.Support
 {
@@ -517,6 +518,7 @@ namespace CoreSystems.Support
                 waterSphere = new BoundingSphereD(ai.MyPlanet.PositionComp.WorldAABB.Center, water.MinRadius);
             var collection = ai.GetProCache(w);
 
+            var wepAiOwnerFactionId = w.Comp.MasterAi.AiOwnerFactionId;
             var lockedOnly = w.System.Values.Targeting.LockedSmartOnly;
             var smartOnly = w.System.Values.Targeting.IgnoreDumbProjectiles;
             var comp = w.Comp;
@@ -582,6 +584,9 @@ namespace CoreSystems.Support
                 var lp = collection[card];
 
                 if (water != null && waterSphere.Contains(lp.Position) == ContainmentType.Contains)
+                    continue;
+                var lpAiOwnerFactionId = lp.Info.Weapon.Comp.MasterAi.AiOwnerFactionId;
+                if (!mOverrides.Neutrals && wepAiOwnerFactionId > 0 && lpAiOwnerFactionId > 0 && MyAPIGateway.Session.Factions.GetRelationBetweenFactions(lpAiOwnerFactionId, wepAiOwnerFactionId) == MyRelationsBetweenFactions.Neutral)
                     continue;
                 var cube = lp.Info.Target.TargetObject as MyCubeBlock;
                 Weapon.TargetOwner tOwner;

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
@@ -252,9 +252,7 @@ namespace CoreSystems.Platform
                     weapon.Comp.DetDps += ammo.Const.DetDps;
                 }
 
-                maxTrajectory = 0;
-                if (weapon.ActiveAmmoDef.AmmoDef.Const.MaxTrajectory > maxTrajectory)
-                    maxTrajectory = weapon.ActiveAmmoDef.AmmoDef.Const.MaxTrajectory;
+                maxTrajectory = weapon.MaxTargetDistance;
 
                 if (weapon.System.TrackProjectile)
                     Ai.PointDefense = true;


### PR DESCRIPTION
-Fixed missing UpdateFactionColors call in AiDatabase refresh 
-Added AiField AiOwnerFactionId
-Added PD targeting check with cached faction data