### PR TITLE
PD Neutral touchup

### DIFF
--- a/Data/CubeBlocks_Weapons.sbc
+++ b/Data/CubeBlocks_Weapons.sbc
@@ -158,7 +158,7 @@
 			<MaxElevationDegrees>90</MaxElevationDegrees>
 			<MinAzimuthDegrees>-180</MinAzimuthDegrees>
 			<MaxAzimuthDegrees>180</MaxAzimuthDegrees>
-			<IdleRotation>true</IdleRotation>
+			<IdleRotation>false</IdleRotation>
 			<MaxRangeMeters>800</MaxRangeMeters>
 			<RotationSpeed>0.0005</RotationSpeed>
 			<ElevationSpeed>0.0005</ElevationSpeed>
@@ -254,7 +254,7 @@
             <MaxAzimuthDegrees>180</MaxAzimuthDegrees>
             <RotationSpeed>0.001</RotationSpeed>
             <ElevationSpeed>0.001 </ElevationSpeed>
-            <IdleRotation>true</IdleRotation>
+            <IdleRotation>false</IdleRotation>
             <MaxRangeMeters>600</MaxRangeMeters>
             <MinFov>0.1</MinFov>
             <MaxFov>1.04719755</MaxFov>
@@ -356,7 +356,7 @@
             <MaxAzimuthDegrees>180</MaxAzimuthDegrees>
             <RotationSpeed>0.001</RotationSpeed>
             <ElevationSpeed>0.001 </ElevationSpeed>
-            <IdleRotation>true</IdleRotation>
+            <IdleRotation>false</IdleRotation>
             <MaxRangeMeters>600</MaxRangeMeters>
             <MinFov>0.1</MinFov>
             <MaxFov>1.04719755</MaxFov>

--- a/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiTargeting.cs
@@ -585,7 +585,7 @@ namespace CoreSystems.Support
 
                 if (water != null && waterSphere.Contains(lp.Position) == ContainmentType.Contains)
                     continue;
-                var lpAiOwnerFactionId = lp.Info.Weapon.Comp.MasterAi.AiOwnerFactionId;
+                var lpAiOwnerFactionId = lp.Info.FactionId;
                 if (!mOverrides.Neutrals && wepAiOwnerFactionId > 0 && lpAiOwnerFactionId > 0 && MyAPIGateway.Session.Factions.GetRelationBetweenFactions(lpAiOwnerFactionId, wepAiOwnerFactionId) == MyRelationsBetweenFactions.Neutral)
                     continue;
                 var cube = lp.Info.Target.TargetObject as MyCubeBlock;

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponComp.cs
@@ -72,12 +72,15 @@ namespace CoreSystems.Platform
                 if (cube != null) 
                 {
                     var turret = coreEntity as IMyLargeTurretBase;
+                    var search = coreEntity as IMySearchlight;
                     if (turret != null)
                     {
                         VanillaTurretBase = turret;
                         VanillaTurretBase.EnableIdleRotation = false;
                         VanillaTurretBase.SetManualAzimuthAndElevation(0, 0);
                     }
+                    else if (search != null)
+                        search.EnableIdleMovement = false;
                 }
                 else if (coreEntity is IMyAutomaticRifleGun)
                 {

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileGen.cs
@@ -83,6 +83,7 @@ namespace CoreSystems.Projectiles
                 info.AcquiredEntity = !aConst.OverrideTarget && wTarget.TargetState == Target.TargetStates.IsEntity;
                 info.ShooterVel = comp.Ai.TopEntityVel;
 
+                info.FactionId = comp.Ai.AiOwnerFactionId;
                 info.OriginUp = t != Kind.Client ? muzzle.UpDirection : gen.OriginUp;
                 info.MaxTrajectory = t != Kind.Client ? aConst.MaxTrajectoryGrows && w.FireCounter < a.Trajectory.MaxTrajectoryTime ? aConst.TrajectoryStep * w.FireCounter : aConst.MaxTrajectory : gen.MaxTrajectory;
                 info.MuzzleId = t != Kind.Virtual ? muzzle.MuzzleId : -1;

--- a/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/ProjectileTypes.cs
@@ -59,6 +59,7 @@ namespace CoreSystems.Support
         internal long DamageDoneShld;
         internal long DamageDoneProj;
         internal long LastTopTargetId;
+        internal long FactionId;
         internal float BaseDamagePool;
         internal float BaseHealthPool;
         internal float BaseEwarPool;
@@ -159,6 +160,7 @@ namespace CoreSystems.Support
             Frags = 0;
             MuzzleId = 0;
             LastTopTargetId = 0;
+            FactionId = 0;
             Age = -1;
             RelativeAge = -1;
             PrevRelativeAge = -1;
@@ -560,6 +562,7 @@ namespace CoreSystems.Support
 
                 frag.Depth = (ushort) (info.SpawnDepth + 1);
 
+                frag.FactionId = info.FactionId;
                 frag.TargetState = targetState;
                 frag.TargetEntity = info.LastTarget;
                 frag.TopEntityId = info.LastTopTargetId;
@@ -619,6 +622,7 @@ namespace CoreSystems.Support
                 target.TopEntityId = frag.TopEntityId;
                 target.TargetPos = frag.TargetPos;
 
+                info.FactionId = frag.FactionId;
                 info.ShotFade = 0;
                 info.IsFragment = true;
                 info.Target.TargetPos = frag.PrevTargetPos;
@@ -682,6 +686,7 @@ namespace CoreSystems.Support
         public Vector3 Gravity;
         public int MuzzleId;
         public ushort Depth;
+        public long FactionId;
 
         public XorShiftRandomStruct Random;
         public bool DoDamage;


### PR DESCRIPTION
Faction ID is cached with the projectile and passed to frags instead of trying to reference back to the firing weapon, as it may no longer exist.