### PR TITLE
Switch projectile API calls to MasterAi

### DIFF
--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -803,12 +803,12 @@ namespace CoreSystems.Api
             var grid = victim.GetTopMostParent();
             Ai ai;
             MyTuple<bool, int, int> tuple;
-            if (grid != null && Session.I.EntityAIs.TryGetValue(grid, out ai))
+            if (grid != null && Session.I.EntityToMasterAi.TryGetValue(grid, out ai))
             {
                 int count = 0;
                 foreach (var proj in ai.LiveProjectile)
                 {
-                    if (proj.Info.Target.TopEntityId == grid.EntityId)
+                    if (proj.Info.Target.TopEntityId == ai.GridEntity.GetTopMostParent().EntityId)
                         count++;
                 }
                 tuple = count > 0 ? new MyTuple<bool, int, int>(true, count, (int) (Session.I.Tick - ai.LiveProjectileTick)) : new MyTuple<bool, int, int>(false, 0, -1);
@@ -823,11 +823,11 @@ namespace CoreSystems.Api
             var grid = victim.GetTopMostParent();
             Ai ai;
             collection.Clear();
-            if (grid != null && Session.I.EntityAIs.TryGetValue(grid, out ai))
+            if (grid != null && Session.I.EntityToMasterAi.TryGetValue(grid, out ai))
             {
                 foreach (var proj in ai.LiveProjectile)
                 {
-                    if(proj.Info.Target.TopEntityId == grid.EntityId)
+                    if(proj.Info.Target.TopEntityId == ai.GridEntity.GetTopMostParent().EntityId)
                         collection.Add(proj.Position);
                 }
             }


### PR DESCRIPTION
Switching to MasterAI and GetTopMostParent() to account for subgrids being targeted.