### PR TITLE
Take 3 on the proj api

### DIFF
--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -805,10 +805,13 @@ namespace CoreSystems.Api
             MyTuple<bool, int, int> tuple;
             if (grid != null && Session.I.EntityToMasterAi.TryGetValue(grid, out ai))
             {
+                var subGridIds = new List<long>();
+                foreach(var subGrid in ai.SubGridCache)
+                    subGridIds.Add(subGrid.EntityId);
                 int count = 0;
                 foreach (var proj in ai.LiveProjectile)
                 {
-                    if (proj.Info.Target.TopEntityId == ai.GridEntity.GetTopMostParent().EntityId)
+                    if (subGridIds.Contains(proj.Info.Target.TopEntityId))
                         count++;
                 }
                 tuple = count > 0 ? new MyTuple<bool, int, int>(true, count, (int) (Session.I.Tick - ai.LiveProjectileTick)) : new MyTuple<bool, int, int>(false, 0, -1);
@@ -825,9 +828,12 @@ namespace CoreSystems.Api
             collection.Clear();
             if (grid != null && Session.I.EntityToMasterAi.TryGetValue(grid, out ai))
             {
+                var subGridIds = new List<long>();
+                foreach (var subGrid in ai.SubGridCache)
+                    subGridIds.Add(subGrid.EntityId);
                 foreach (var proj in ai.LiveProjectile)
                 {
-                    if(proj.Info.Target.TopEntityId == ai.GridEntity.GetTopMostParent().EntityId)
+                    if(subGridIds.Contains(proj.Info.Target.TopEntityId))
                         collection.Add(proj.Position);
                 }
             }


### PR DESCRIPTION
Subgrid shenanigans strike again.  It may be worth exploring adding a list to AI to disambiguate projectiles worth tracking from those actively locked on, and only populating projectile lists for master AIs when the initial PD check occurs in GenProjectiles