### PR TITLE
sequencing BurstCount fix

### DIFF
--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponData.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponData.cs
@@ -135,6 +135,8 @@ namespace CoreSystems.Platform
                             if (w.System.Values.HardPoint.HardWare.CriticalReaction.DefaultArmedTimer > Repo.Values.Set.Overrides.ArmedTimer)
                                 Repo.Values.Set.Overrides.ArmedTimer = w.System.Values.HardPoint.HardWare.CriticalReaction.DefaultArmedTimer;
 
+                            if (Comp.HasDisabledBurst)
+                                Repo.Values.Set.Overrides.BurstCount = w.System.Values.HardPoint.Loading.ShotsInBurst;
                         }
                     }
 


### PR DESCRIPTION
- Fixed burst count defaulting to 1 for certain sequencing actions, resulting in short cycling of weapons