### PR TITLE
allow WCVanilla as suffix, not just prefix

### DIFF
--- a/Data/Scripts/CoreSystems/Session/SessionSupport.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionSupport.cs
@@ -1195,7 +1195,9 @@ namespace CoreSystems
                     ShieldMod = true;
                 else if (mod.PublishedFileId == 1931509062 || mod.PublishedFileId == 1995197719 || mod.PublishedFileId == 2006751214 || mod.PublishedFileId == 2015560129)
                     ReplaceVanilla = true;
-                else if (mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\VanillaReplacement") || mod.Name.StartsWith("WCVanilla") || mod.FriendlyName.StartsWith("WCVanilla"))
+                else if (mod.GetPath().Contains("AppData\\Roaming\\SpaceEngineers\\Mods\\VanillaReplacement")
+                         || mod.Name.StartsWith("WCVanilla") || mod.FriendlyName.StartsWith("WCVanilla")
+                         || mod.Name.EndsWith("WCVanilla") || mod.FriendlyName.EndsWith("WCVanilla"))
                     ReplaceVanilla = true;
                 else if (mod.PublishedFileId == 2189703321 || mod.PublishedFileId == 2496225055 || mod.PublishedFileId == 2726343161 || mod.PublishedFileId == 2734980390)
                 {


### PR DESCRIPTION
A suffix is less intrusive as it still allows naming mods normally with alphabetical order matching.