### PR TITLE
Updates

### DIFF
--- a/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
@@ -247,9 +247,11 @@ namespace CoreSystems.Support
 
                     var endReturn = i + 1 != collection.Count ? "\n" : string.Empty;
                     var timeToLoad = (int)(w.ReloadEndTick - Session.I.Tick) / 60;
+                    var showName = w.ActiveAmmoDef.AmmoDef.AmmoRound != w.ActiveAmmoDef.AmmoDef.Const.MagazineDef.DisplayNameText;
+                    var displayName = showName ? w.ActiveAmmoDef.AmmoDef.AmmoRound + " (" + w.ActiveAmmoDef.AmmoDef.Const.MagazineDef.DisplayNameText + ")" : w.ActiveAmmoDef.AmmoDef.AmmoRound;
                     stringBuilder.Append($"\n\n" + w.System.PartName +
                         shots +
-                        $" {(w.ActiveAmmoDef.AmmoDef.Const.EnergyAmmo ? string.Empty : "\n" + (w.Loading ? timeToLoad < 0 ? "Waiting on charge" : "Loaded in " + timeToLoad + "s" : w.ProtoWeaponAmmo.CurrentAmmo > 0 ? "Loaded " + w.ProtoWeaponAmmo.CurrentAmmo + "x " + w.ActiveAmmoDef.AmmoDef.AmmoRound : "No Ammo"))}" +
+                        $" {(w.ActiveAmmoDef.AmmoDef.Const.EnergyAmmo ? string.Empty : "\n" + (w.Loading ? timeToLoad < 0 ? "Waiting on charge" : "Loaded in " + timeToLoad + "s" : w.ProtoWeaponAmmo.CurrentAmmo > 0 ? "Loaded " + w.ProtoWeaponAmmo.CurrentAmmo + "x " + displayName : "No Ammo"))}" +
                         $" {(w.ActiveAmmoDef.AmmoDef.Const.RequiresTarget ? "\n" + Localization.GetText("WeaponInfoHasTarget") + ": " + w.Target.HasTarget : string.Empty)}" +
                         $" {(w.ActiveAmmoDef.AmmoDef.Const.RequiresTarget ? "\n" + Localization.GetText("WeaponInfoLoS") + ": " + (w.Target.HasTarget ? "" + !w.PauseShoot : "No Target") : string.Empty)}" +
                         endReturn);
@@ -305,9 +307,9 @@ namespace CoreSystems.Support
                                     continue;
 
                                 if (otherAmmo == null)
-                                    otherAmmo = "\n\nMagazine Types:";
-
-                                otherAmmo += $"\n{ammo.AmmoDef.AmmoRound}";
+                                    otherAmmo = "\n\nAmmo Name (Mag if different)";
+                                var showName =  ammo.AmmoDef.AmmoRound != ammo.AmmoDef.Const.MagazineDef.DisplayNameText;
+                                otherAmmo += $"\n{ammo.AmmoDef.AmmoRound} {(showName ? "(" + ammo.AmmoDef.Const.MagazineDef.DisplayNameText + ")" : "")}";
                             }
 
                             if (otherAmmo != null)

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponReload.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponReload.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using CoreSystems.Support;
-using VRageMath;
+using VRage.Utils;
 using static CoreSystems.Support.CoreComponent;
 using static CoreSystems.Support.WeaponDefinition.AnimationDef.PartAnimationSetDef;
 
@@ -208,11 +208,10 @@ namespace CoreSystems.Platform
                     var magsRequested = (int)((System.FullAmmoVolume - CurrentAmmoVolume) / ActiveAmmoDef.AmmoDef.Const.MagVolume + .0001f);
                     var magsGranted = magsRequested > spotsFree ? spotsFree : magsRequested;
                     var requestedVolume = ActiveAmmoDef.AmmoDef.Const.MagVolume * magsGranted;
-                    var spaceAvailable = freeVolume >= requestedVolume;
+                    var spaceAvailable = freeVolume >= requestedVolume || MyUtils.IsEqual(freeVolume, requestedVolume);
                     var pullAmmo = magsGranted > 0 && CurrentAmmoVolume < System.LowAmmoVolume && spaceAvailable;
                     
                     var failSafeTimer = s.Tick - LastInventoryTick > 600;
-                    
                     if (pullAmmo && (CheckInventorySystem || failSafeTimer && Comp.Ai.Construct.RootAi.Construct.OutOfAmmoWeapons.Contains(this)) && s.PartToPullConsumable.TryAdd(this, byte.MaxValue)) {
 
                         CheckInventorySystem = false;


### PR DESCRIPTION
- Revised terminal info to show internal WC ammo name followed by inventory item name in parenthesis if they are different
- "Force Reload" on block weapons/turrets will now kick out any full magazines to inventory.  If a magazine is partially expended or there isn't enough room in the weapon's inventory, it will be lost
- Fixed floating point error in ammo inventory pull logic