### PR TITLE
Create Add/RemoveScanTargetsAction API Hooks

### DIFF
--- a/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
+++ b/Data/Scripts/CoreSystems/Ai/AiDatabase.cs
@@ -40,7 +40,10 @@ namespace CoreSystems.Support
 
         internal void Scan()
         {
-            MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref ScanVolume, _possibleTargets);
+            if (Session.I.ScanTargetsAction == null)
+                MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref ScanVolume, _possibleTargets);
+            else
+                Session.I.ScanTargetsAction.Invoke(GridEntity, ScanVolume, _possibleTargets);
             NearByEntitiesTmp = _possibleTargets.Count;
 
             for (int i = 0; i < NearByEntitiesTmp; i++)

--- a/Data/Scripts/CoreSystems/Api/ApiBackend.cs
+++ b/Data/Scripts/CoreSystems/Api/ApiBackend.cs
@@ -141,6 +141,8 @@ namespace CoreSystems.Api
                 ["IsInRange"] = new Func<IMyEntity, MyTuple<bool, bool>>(IsInRangeLegacy),
                 ["GetConstructEffectiveDpsBase"] = new Func<MyEntity, float>(GetConstructEffectiveDps),
                 ["GetConstructEffectiveDps"] = new Func<IMyEntity, float>(GetConstructEffectiveDpsLegacy),
+                ["AddScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(AddScanTargetsAction),
+                ["RemoveScanTargetsAction"] = new Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>>(RemoveScanTargetsAction),
 
                 // Phantoms
                 ["GetTargetAssessment"] = new Func<MyEntity, MyEntity, int, bool, bool, MyTuple<bool, bool, Vector3D?>>(GetPhantomTargetAssessment),
@@ -1509,6 +1511,18 @@ namespace CoreSystems.Api
             }
             return new MyTuple<bool, bool>();
         }
+
+        private void AddScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action)
+        {
+            Session.I.ScanTargetsAction += action;
+        }
+
+        private void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action)
+        {
+            Session.I.ScanTargetsAction -= action;
+        }
+
+
         ///
         /// Phantoms
         /// 

--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Sandbox.Game.Entities;
 using Sandbox.ModAPI;
 using VRage;
 using VRage.Collections;
@@ -91,6 +92,8 @@ namespace CoreSystems.Api
         private Func<MyEntity, int, MyTuple<MyDefinitionId, string, string, bool>> _getMagazineMap;
         private Func<MyEntity, int, MyDefinitionId, bool, bool> _setMagazine;
         private Func<MyEntity, int, bool> _forceReload;
+        private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _addScanTargetsAction;
+        private Action<Action<MyCubeGrid, BoundingSphereD, List<MyEntity>>> _removeScanTargetsAction;
 
         public void SetWeaponTarget(MyEntity weapon, MyEntity target, int weaponId = 0) =>
             _setWeaponTarget?.Invoke(weapon, target, weaponId);
@@ -467,6 +470,18 @@ namespace CoreSystems.Api
 
         }
 
+        /// <summary>
+        /// Registers an action that tells a given grid's AI available target entities in a given sphere.
+        /// </summary>
+        /// <param name="action"></param>
+        public void AddScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _addScanTargetsAction?.Invoke(action);
+
+        /// <summary>
+        /// Unregisters an action that tells a given grid's AI available target entities in a given sphere.
+        /// </summary>
+        /// <param name="action"></param>
+        public void RemoveScanTargetsAction(Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> action) => _removeScanTargetsAction?.Invoke(action);
+
         private const long Channel = 67549756549;
         private bool _getWeaponDefinitions;
         private bool _isRegistered;
@@ -616,6 +631,9 @@ namespace CoreSystems.Api
 
             AssignMethod(delegates, "SetMagazine", ref _setMagazine);
             AssignMethod(delegates, "ForceReload", ref _forceReload);
+
+            AssignMethod(delegates, "AddScanTargetsAction", ref _addScanTargetsAction);
+            AssignMethod(delegates, "RemoveScanTargetsAction", ref _removeScanTargetsAction);
 
             // Damage handler
             AssignMethod(delegates, "DamageHandler", ref _registerDamageEvent);

--- a/Data/Scripts/CoreSystems/Session/SessionFields.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionFields.cs
@@ -332,6 +332,7 @@ namespace CoreSystems
         internal Projectiles.Projectiles Projectiles;
         internal ApiBackend Api;
         internal Action<Vector3, float> ProjectileAddedCallback = (location, health) => { };
+        internal Action<MyCubeGrid, BoundingSphereD, List<MyEntity>> ScanTargetsAction = null;
         internal ShieldApi SApi = new ShieldApi();
         internal NetworkReporter Reporter = new NetworkReporter();
         internal MyStorageData TmpStorage = new MyStorageData();


### PR DESCRIPTION
Allows mods to set which targets are visible to a grid's AI.