### PR TITLE
Updates

### DIFF
--- a/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+++ b/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
@@ -12,7 +12,7 @@ using VRageMath;
 namespace CoreSystems.Api
 {
     /// <summary>
-    /// https://github.com/sstixrud/CoreSystems/blob/master/BaseData/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
+    /// https://github.com/Ash-LikeSnow/WeaponCore/blob/master/Data/Scripts/CoreSystems/Api/CoreSystemsApiBase.cs
     /// </summary>
     public partial class WcApi
     {

--- a/Data/Scripts/CoreSystems/AudioVisual/AvShot.cs
+++ b/Data/Scripts/CoreSystems/AudioVisual/AvShot.cs
@@ -1232,6 +1232,8 @@ namespace CoreSystems.Support
 
             for (int v = 0; v < p.VrPros.Count; v++)
             {
+                if (p.State == ProjectileState.Dead)
+                    break;
                 var vp = p.VrPros[v];
                 var vs = vp.AvShot;
 

--- a/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
+++ b/Data/Scripts/CoreSystems/Definitions/CoreDefinitions.cs
@@ -1341,6 +1341,7 @@ namespace CoreSystems.Support
                     [ProtoMember(23)] internal double MinTurnSpeed;
                     [ProtoMember(24)] internal bool NoTargetApproach;
                     [ProtoMember(25)] internal bool AltNavigation;
+                    [ProtoMember(26)] internal bool IgnoreAntiSmarts;
                 }
 
                 [ProtoContract]

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -249,6 +249,7 @@ namespace CoreSystems.Support
         public readonly bool ProjectilesFirst;
         public readonly bool OnHit;
         public readonly bool OverrideWeaponEffect;
+        public readonly bool IgnoreAntiSmarts;
         public readonly float LargeGridDmgScale;
         public readonly float SmallGridDmgScale;
         public readonly float OffsetRatio;
@@ -405,7 +406,7 @@ namespace CoreSystems.Support
 
             ComputeSmarts(ammo, out IsSmart, out Roam, out NoTargetApproach, out AccelClearance, out OverrideTarget, out TargetOffSet,
                 out FocusOnly, out FocusEviction, out NoSteering, out AdvancedSmartSteering, out KeepAliveAfterTargetLoss, out NoTargetExpire, out ZeroEffortNav, out ScanRange, out OffsetMinRangeSqr,
-                out Aggressiveness, out NavAcceleration, out MinTurnSpeedSqr, out OffsetRatio, out MaxChaseTime, out MaxTargets, out OffsetTime);
+                out Aggressiveness, out NavAcceleration, out MinTurnSpeedSqr, out OffsetRatio, out MaxChaseTime, out MaxTargets, out OffsetTime, out IgnoreAntiSmarts);
 
             IsGuided = TravelTo || IsMine || IsDrone || IsSmart;
 
@@ -598,7 +599,7 @@ namespace CoreSystems.Support
 
         private void ComputeSmarts(WeaponSystem.AmmoType ammo, out bool isSmart, out bool roam, out bool noTargetApproach, out bool accelClearance, out bool overrideTarget, out bool targetOffSet,
             out bool focusOnly, out bool focusEviction, out bool noSteering, out bool advancedSmartSteering, out bool keepAliveAfterTargetLoss, out bool noTargetExpire, out bool zeroEffortNav, out double scanRange, out double offsetMinRangeSqr,
-            out double aggressiveness, out double navAcceleration, out double minTurnSpeedSqr, out float offsetRatio, out int maxChaseTime, out int maxTargets, out int offsetTime)
+            out double aggressiveness, out double navAcceleration, out double minTurnSpeedSqr, out float offsetRatio, out int maxChaseTime, out int maxTargets, out int offsetTime, out bool ignoreAntiSmarts)
         {
             isSmart = ammo.AmmoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.Smart || ammo.AmmoDef.Trajectory.Guidance == TrajectoryDef.GuidanceType.DetectSmart;
 
@@ -633,6 +634,7 @@ namespace CoreSystems.Support
             offsetTime = ammo.AmmoDef.Trajectory.Smarts.OffsetTime;
             noTargetApproach = ammo.AmmoDef.Trajectory.Smarts.NoTargetApproach;
             zeroEffortNav = ammo.AmmoDef.Trajectory.Smarts.AltNavigation;
+            ignoreAntiSmarts = ammo.AmmoDef.Trajectory.Smarts.IgnoreAntiSmarts;
         }
 
 

--- a/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
+++ b/Data/Scripts/CoreSystems/Definitions/SerializedConfigs/AmmoConstants.cs
@@ -1251,34 +1251,6 @@ namespace CoreSystems.Support
 
         }
 
-        //private void GetModifiableValues(AmmoDef ammoDef, out float baseDamage, out float health, out float gravityMultiplier, out float maxTrajectory, out float maxTrajectorySqr, out bool energyBaseDmg, out bool energyAreaDmg, out bool energyDetDmg, out bool energyShieldDmg, out double shieldModifier, out float fallOffDistance, out float fallOffMinMult, out float mass, out float shieldBypassRaw)
-        //{
-        //    baseDamage = AmmoModsFound && _modifierMap[BaseDmgStr].HasData() ? _modifierMap[BaseDmgStr].GetAsFloat : ammoDef.BaseDamage;
-
-        //    if (baseDamage < 0.000001)
-        //        baseDamage = 0.000001f;
-
-        //    health = AmmoModsFound && _modifierMap[HealthStr].HasData() ? _modifierMap[HealthStr].GetAsFloat : ammoDef.Health;
-        //    gravityMultiplier = AmmoModsFound && _modifierMap[GravityStr].HasData() ? _modifierMap[GravityStr].GetAsFloat : ammoDef.Trajectory.GravityMultiplier;
-        //    maxTrajectory = AmmoModsFound && _modifierMap[MaxTrajStr].HasData() ? _modifierMap[MaxTrajStr].GetAsFloat : ammoDef.Trajectory.MaxTrajectory;
-        //    maxTrajectorySqr = maxTrajectory * maxTrajectory;
-        //    energyBaseDmg = AmmoModsFound && _modifierMap[EnergyBaseDmgStr].HasData() ? _modifierMap[EnergyBaseDmgStr].GetAsBool : ammoDef.DamageScales.DamageType.Base != DamageTypes.Damage.Kinetic;
-        //    energyAreaDmg = AmmoModsFound && _modifierMap[EnergyAreaDmgStr].HasData() ? _modifierMap[EnergyAreaDmgStr].GetAsBool : ammoDef.DamageScales.DamageType.AreaEffect != DamageTypes.Damage.Kinetic;
-        //    energyDetDmg = AmmoModsFound && _modifierMap[EnergyDetDmgStr].HasData() ? _modifierMap[EnergyDetDmgStr].GetAsBool : ammoDef.DamageScales.DamageType.Detonation != DamageTypes.Damage.Kinetic;
-        //    energyShieldDmg = AmmoModsFound && _modifierMap[EnergyShieldDmgStr].HasData() ? _modifierMap[EnergyShieldDmgStr].GetAsBool : ammoDef.DamageScales.DamageType.Shield != DamageTypes.Damage.Kinetic;
-
-        //    var givenShieldModifier = AmmoModsFound && _modifierMap[ShieldModStr].HasData() ? _modifierMap[ShieldModStr].GetAsDouble : ammoDef.DamageScales.Shields.Modifier;
-        //    shieldModifier = givenShieldModifier < 0 ? 1 : givenShieldModifier;
-
-        //    fallOffDistance = AmmoModsFound && _modifierMap[FallOffDistanceStr].HasData() ? _modifierMap[FallOffDistanceStr].GetAsFloat : ammoDef.DamageScales.FallOff.Distance;
-        //    fallOffMinMult = AmmoModsFound && _modifierMap[FallOffMinMultStr].HasData() ? _modifierMap[FallOffMinMultStr].GetAsFloat : ammoDef.DamageScales.FallOff.MinMultipler;
-
-        //    mass = AmmoModsFound && _modifierMap[MassStr].HasData() ? _modifierMap[MassStr].GetAsFloat : ammoDef.Mass;
-
-        //    shieldBypassRaw = AmmoModsFound && _modifierMap[ShieldBypassStr].HasData() ? _modifierMap[ShieldBypassStr].GetAsFloat : ammoDef.DamageScales.Shields.BypassModifier;
-        //}
-
-
         private int mexLogLevel = 0;
         private void GetPeakDps(WeaponSystem.AmmoType ammoDef, WeaponSystem system, WeaponDefinition wDef, out float peakDps, out float effectiveDps, out float dpsWoInaccuracy, out float shotsPerSec, out float realShotsPerSec, out float baseDps, out float areaDps, out float detDps, out float realShotsPerMin)
         {

--- a/Data/Scripts/CoreSystems/EntityComp/Controls/TerminalHelpers.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Controls/TerminalHelpers.cs
@@ -73,51 +73,31 @@ namespace CoreSystems.Control
         internal static void AddTurretControlBlockControls<T>(Session session) where T : IMyTerminalBlock
         {
             CtcAddListBoxNoAction<T>(session, "ToolsAndWeapons", "Available tools and weapons", "Auto populated by weaponcore", BlockUi.ToolWeaponFill, BlockUi.ToolWeaponSelect, CtcIsReady, 4, true);
-
             CtcAddCheckboxNoAction<T>(session, "Advanced", Localization.GetText("TerminalAdvancedTitle"), Localization.GetText("TerminalAdvancedTooltip"), BlockUi.GetAdvancedControl, BlockUi.RequestAdvancedControl, true, CtcIsReady);
             CtcAddOnOffSwitchNoAction<T>(session, "ShareFireControlEnabled", Localization.GetText("TerminalShareFireControlTitle"), Localization.GetText("TerminalShareFireControlTooltip"), BlockUi.GetShareFireControlControl, BlockUi.RequestShareFireControlControl, true, CtcIsReady);
-
             CtcAddOnOffSwitchNoAction<T>(session, "WCAiEnabled", Localization.GetText("TerminalAiEnabledTitle"), Localization.GetText("TerminalAiEnabledTooltip"), BlockUi.GetAiEnabledControl, BlockUi.RequestSetAiEnabledControl, true, CtcIsReady);
+            CtcAddComboboxNoAction<T>(session, "ControlModes", Localization.GetText("TerminalControlModesTitle"), Localization.GetText("TerminalControlModesTooltip"), BlockUi.GetControlModeControl, BlockUi.RequestControlModeControl, BlockUi.ListControlModes, CtcIsReady);
+            CtcAddComboboxNoAction<T>(session, "TrackingMode", Localization.GetText("TerminalTrackingModeTitle"), Localization.GetText("TerminalTrackingModeTooltip"), BlockUi.GetMovementModeControl, BlockUi.RequestMovementModeControl, BlockUi.ListMovementModes, CtcIsReady);
+            AddWeaponCtcRangeSliderNoAction<T>(session, "Weapon Range", Localization.GetText("TerminalWeaponRangeTitle"), Localization.GetText("TerminalWeaponRangeTooltip"), BlockUi.GetRangeControl, BlockUi.RequestSetRangeControl, CtcIsReady, BlockUi.GetMinRangeControl, BlockUi.GetMaxRangeControl, true, false);
 
             Separator<T>(session, "WC_sep2", IsTrue);
 
-            AddWeaponCtcRangeSliderNoAction<T>(session, "Weapon Range", Localization.GetText("TerminalWeaponRangeTitle"), Localization.GetText("TerminalWeaponRangeTooltip"), BlockUi.GetRangeControl, BlockUi.RequestSetRangeControl, CtcIsReady, BlockUi.GetMinRangeControl, BlockUi.GetMaxRangeControl, true, false);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "ReportTarget", Localization.GetText("TerminalReportTargetTitle"), Localization.GetText("TerminalReportTargetTooltip"), BlockUi.GetReportTargetControl, BlockUi.RequestSetReportTargetControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Neutrals", Localization.GetText("TerminalNeutralsTitle"), Localization.GetText("TerminalNeutralsTooltip"), BlockUi.GetNeutralsControl, BlockUi.RequestSetNeutralsControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Unowned", Localization.GetText("TerminalUnownedTitle"), Localization.GetText("TerminalUnownedTooltip"), BlockUi.GetUnownedControl, BlockUi.RequestSetUnownedControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Biologicals", Localization.GetText("TerminalBiologicalsTitle"), Localization.GetText("TerminalBiologicalsTooltip"), BlockUi.GetBiologicalsControl, BlockUi.RequestSetBiologicalsControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Projectiles", Localization.GetText("TerminalProjectilesTitle"), Localization.GetText("TerminalProjectilesTooltip"), BlockUi.GetProjectilesControl, BlockUi.RequestSetProjectilesControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Supporting PD", Localization.GetText("TerminalSupportingPDTitle"), Localization.GetText("TerminalSupportingPDTooltip"), BlockUi.GetSupportingPDControl, BlockUi.RequestSetSupportingPDControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "Meteors", Localization.GetText("TerminalMeteorsTitle"), Localization.GetText("TerminalMeteorsTooltip"), BlockUi.GetMeteorsControl, BlockUi.RequestSetMeteorsControl, true, CtcIsReady);
-
-            CtcAddOnOffSwitchNoAction<T>(session, "FocusFire", Localization.GetText("TerminalFocusFireTitle"), Localization.GetText("TerminalFocusFireTooltip"), BlockUi.GetFocusFireControl, BlockUi.RequestSetFocusFireControl, true, CtcIsReady);
-
             CtcAddOnOffSwitchNoAction<T>(session, "SubSystems", Localization.GetText("TerminalSubSystemsTitle"), Localization.GetText("TerminalSubSystemsTooltip"), BlockUi.GetSubSystemsControl, BlockUi.RequestSetSubSystemsControl, true, CtcIsReady);
-
             CtcAddComboboxNoAction<T>(session, "PickSubSystem", Localization.GetText("TerminalPickSubSystemTitle"), Localization.GetText("TerminalPickSubSystemTooltip"), BlockUi.GetSubSystemControl, BlockUi.RequestSubSystemControl, BlockUi.ListSubSystems, CtcIsReady);
 
+            CtcAddOnOffSwitchNoAction<T>(session, "FocusFire", Localization.GetText("TerminalFocusFireTitle"), Localization.GetText("TerminalFocusFireTooltip"), BlockUi.GetFocusFireControl, BlockUi.RequestSetFocusFireControl, true, CtcIsReady);
             CtcAddOnOffSwitchNoAction<T>(session, "Repel", Localization.GetText("TerminalRepelTitle"), Localization.GetText("TerminalRepelTooltip"), BlockUi.GetRepelControl, BlockUi.RequestSetRepelControl, true, CtcIsReady);
 
+            CtcAddOnOffSwitchNoAction<T>(session, "Neutrals", Localization.GetText("TerminalNeutralsTitle"), Localization.GetText("TerminalNeutralsTooltip"), BlockUi.GetNeutralsControl, BlockUi.RequestSetNeutralsControl, true, CtcIsReady);
+            CtcAddOnOffSwitchNoAction<T>(session, "Unowned", Localization.GetText("TerminalUnownedTitle"), Localization.GetText("TerminalUnownedTooltip"), BlockUi.GetUnownedControl, BlockUi.RequestSetUnownedControl, true, CtcIsReady);
             CtcAddOnOffSwitchNoAction<T>(session, "Grids", Localization.GetText("TerminalGridsTitle"), Localization.GetText("TerminalGridsTooltip"), BlockUi.GetGridsControl, BlockUi.RequestSetGridsControl, true, CtcIsReady);
-
             CtcAddOnOffSwitchNoAction<T>(session, "LargeGrid", Localization.GetText("TerminalLGTitle"), Localization.GetText("TerminalLGTooltip"), BlockUi.GetLargeGridControl, BlockUi.RequestSetLargeGridControl, true, CtcIsReady);
-
             CtcAddOnOffSwitchNoAction<T>(session, "SmallGrid", Localization.GetText("TerminalSGTitle"), Localization.GetText("TerminalSGTooltip"), BlockUi.GetSmallGridControl, BlockUi.RequestSetSmallGridControl, true, CtcIsReady);
-
-            Separator<T>(session, "WC_sep3", IsTrue);
-
-            CtcAddComboboxNoAction<T>(session, "TrackingMode", Localization.GetText("TerminalTrackingModeTitle"), Localization.GetText("TerminalTrackingModeTooltip"), BlockUi.GetMovementModeControl, BlockUi.RequestMovementModeControl, BlockUi.ListMovementModes, CtcIsReady);
-
-            CtcAddComboboxNoAction<T>(session, "ControlModes", Localization.GetText("TerminalControlModesTitle"), Localization.GetText("TerminalControlModesTooltip"), BlockUi.GetControlModeControl, BlockUi.RequestControlModeControl, BlockUi.ListControlModes, CtcIsReady);
-
-            Separator<T>(session, "WC_sep4", IsTrue);
+            CtcAddOnOffSwitchNoAction<T>(session, "Biologicals", Localization.GetText("TerminalBiologicalsTitle"), Localization.GetText("TerminalBiologicalsTooltip"), BlockUi.GetBiologicalsControl, BlockUi.RequestSetBiologicalsControl, true, CtcIsReady);
+            CtcAddOnOffSwitchNoAction<T>(session, "Projectiles", Localization.GetText("TerminalProjectilesTitle"), Localization.GetText("TerminalProjectilesTooltip"), BlockUi.GetProjectilesControl, BlockUi.RequestSetProjectilesControl, true, CtcIsReady);
+            CtcAddOnOffSwitchNoAction<T>(session, "Supporting PD", Localization.GetText("TerminalSupportingPDTitle"), Localization.GetText("TerminalSupportingPDTooltip"), BlockUi.GetSupportingPDControl, BlockUi.RequestSetSupportingPDControl, true, CtcIsReady);
+            CtcAddOnOffSwitchNoAction<T>(session, "Meteors", Localization.GetText("TerminalMeteorsTitle"), Localization.GetText("TerminalMeteorsTooltip"), BlockUi.GetMeteorsControl, BlockUi.RequestSetMeteorsControl, true, CtcIsReady);
+            CtcAddOnOffSwitchNoAction<T>(session, "ReportTarget", Localization.GetText("TerminalReportTargetTitle"), Localization.GetText("TerminalReportTargetTooltip"), BlockUi.GetReportTargetControl, BlockUi.RequestSetReportTargetControl, true, CtcIsReady);
         }
 
         internal static void AddSearchlightControls<T>(Session session) where T : IMyTerminalBlock
@@ -125,25 +105,15 @@ namespace CoreSystems.Control
             Separator<T>(session, "WC_sep2", HasTracking);
 
             AddWeaponRangeSliderNoAction<T>(session, "Weapon Range", Localization.GetText("TerminalWeaponRangeTitle"), Localization.GetText("TerminalWeaponRangeTooltip"), BlockUi.GetRange, BlockUi.RequestSetRange, BlockUi.ShowRange, BlockUi.GetMinRange, BlockUi.GetMaxRange, true, false);
-
             AddOnOffSwitchNoAction<T>(session, "Neutrals", Localization.GetText("TerminalNeutralsTitle"), Localization.GetText("TerminalNeutralsTooltip"), BlockUi.GetNeutrals, BlockUi.RequestSetNeutrals, true, HasTrackingNeutrals);
-
             AddOnOffSwitchNoAction<T>(session, "Unowned", Localization.GetText("TerminalUnownedTitle"), Localization.GetText("TerminalUnownedTooltip"), BlockUi.GetUnowned, BlockUi.RequestSetUnowned, true, HasTrackingUnowned);
-
             AddOnOffSwitchNoAction<T>(session, "Grids", Localization.GetText("TerminalGridsTitle"), Localization.GetText("TerminalGridsTooltip"), BlockUi.GetGrids, BlockUi.RequestSetGrids, true, TrackGrids);
-
             AddOnOffSwitchNoAction<T>(session, "LargeGrid", Localization.GetText("TerminalLGTitle"), Localization.GetText("TerminalLGTooltip"), BlockUi.GetLargeGrid, BlockUi.RequestSetLargeGrid, true, HasTracking);
-
             AddOnOffSwitchNoAction<T>(session, "SmallGrid", Localization.GetText("TerminalSGTitle"), Localization.GetText("TerminalSGTooltip"), BlockUi.GetSmallGrid, BlockUi.RequestSetSmallGrid, true, HasTracking);
-
             AddOnOffSwitchNoAction<T>(session, "Biologicals", Localization.GetText("TerminalBiologicalsTitle"), Localization.GetText("TerminalBiologicalsTooltip"), BlockUi.GetBiologicals, BlockUi.RequestSetBiologicals, true, TrackBiologicals);
-
             AddOnOffSwitchNoAction<T>(session, "Projectiles", Localization.GetText("TerminalProjectilesTitle"), Localization.GetText("TerminalProjectilesTooltip"), BlockUi.GetProjectiles, BlockUi.RequestSetProjectiles, true, TrackProjectiles);
-
             AddOnOffSwitchNoAction<T>(session, "Meteors", Localization.GetText("TerminalMeteorsTitle"), Localization.GetText("TerminalMeteorsTooltip"), BlockUi.GetMeteors, BlockUi.RequestSetMeteors, true, TrackMeteors);
-
             AddWeaponCameraSliderRange<T>(session, "Camera Channel", Localization.GetText("TerminalCameraChannelTitle"), Localization.GetText("TerminalCameraChannelTooltip"), BlockUi.GetWeaponCamera, BlockUi.RequestSetBlockCamera, HasTracking, BlockUi.GetMinCameraChannel, BlockUi.GetMaxCameraChannel, true);
-
         }
         internal static void AddDecoyControls<T>(Session session) where T : IMyTerminalBlock
         {

--- a/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/EntityEvents.cs
@@ -269,7 +269,7 @@ namespace CoreSystems.Support
                     stringBuilder.Append($" {(collection.Count > 1 ? "\n{w.FriendlyName}" : string.Empty)}" +
                         $"{(w.MinTargetDistance > 0 ? $"\n{Localization.GetText("WeaponInfoMinRange")}: {w.MinTargetDistance}{Localization.GetText("WeaponInfoMeter")}" : string.Empty)}" +
                         $"\n{Localization.GetText("WeaponInfoMaxRange")}: {w.MaxTargetDistance}{Localization.GetText("WeaponInfoMeter")}" +
-                        $"\n{Localization.GetText("WeaponInfoROF")}: {w.ActiveAmmoDef.AmmoDef.Const.RealShotsPerMin}{Localization.GetText("WeaponInfoPerMin")}");
+                        $"\n{Localization.GetText("WeaponInfoROF")}: {w.ActiveAmmoDef.AmmoDef.Const.RealShotsPerMin:0.}{Localization.GetText("WeaponInfoPerMin")}");
                     if(w.ActiveAmmoDef.AmmoDef.Const.RequiresTarget)
                     {
                         var targ = $"{Localization.GetText("WeaponInfoTargetLabel")}: ";

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponReload.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponReload.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using CoreSystems.Support;
+using VRage.Game.Entity;
 using VRage.Utils;
 using static CoreSystems.Support.CoreComponent;
 using static CoreSystems.Support.WeaponDefinition.AnimationDef.PartAnimationSetDef;
@@ -255,35 +256,31 @@ namespace CoreSystems.Platform
             ++ClientStartId;
             ++Reload.LifetimeLoads;
 
-            if (!ActiveAmmoDef.AmmoDef.Const.EnergyAmmo) {
-
+            if (!ActiveAmmoDef.AmmoDef.Const.EnergyAmmo)
+            {
                 var isPhantom = Comp.TypeSpecific == CompTypeSpecific.Phantom;
                 Reload.MagsLoaded = ActiveAmmoDef.AmmoDef.Const.MagsToLoad <= Reload.CurrentMags || Session.I.IsCreative ? ActiveAmmoDef.AmmoDef.Const.MagsToLoad : Reload.CurrentMags;
-                
-                if (!Session.I.IsCreative)
-                {
-                    if (!isPhantom && Comp.CoreInventory.ItemsCanBeRemoved(Reload.MagsLoaded, ActiveAmmoDef.AmmoDef.Const.AmmoItem))
-                    {
-                        if (System.HasAmmoSelection) {
-                            var magItem = Comp.CoreInventory.FindItem(ActiveAmmoDef.AmmoDefinitionId) ?? ActiveAmmoDef.AmmoDef.Const.AmmoItem;
-                            Comp.CoreInventory.RemoveItems(magItem.ItemId, Reload.MagsLoaded);
-                        }
-                        else
-                        {
-                            var magItem = Comp.TypeSpecific == CompTypeSpecific.Rifle ? Comp.CoreInventory.FindItem(ActiveAmmoDef.AmmoDefinitionId) ?? ActiveAmmoDef.AmmoDef.Const.AmmoItem : ActiveAmmoDef.AmmoDef.Const.AmmoItem;
-                            Comp.CoreInventory.RemoveItems(magItem.ItemId, Reload.MagsLoaded);
-                        }
-                    }
-                    else if (!isPhantom && Comp.CoreInventory.ItemCount > 0 && Comp.CoreInventory.ContainItems(Reload.MagsLoaded, ActiveAmmoDef.AmmoDef.Const.AmmoItem.Content))
-                    {
-                        Comp.CoreInventory.Remove(ActiveAmmoDef.AmmoDef.Const.AmmoItem, Reload.MagsLoaded);
-                    }
-                }
 
+                if (!Session.I.IsCreative && !isPhantom)
+                {
+                    if (Comp.CoreInventory.ItemsCanBeRemoved(Reload.MagsLoaded, ActiveAmmoDef.AmmoDef.Const.AmmoItem))
+                    {
+                        MyPhysicalInventoryItem magItem;
+                        if (System.HasAmmoSelection)
+                            magItem = Comp.CoreInventory.FindItem(ActiveAmmoDef.AmmoDefinitionId) ?? ActiveAmmoDef.AmmoDef.Const.AmmoItem;
+                        else
+                            magItem = Comp.TypeSpecific == CompTypeSpecific.Rifle ? Comp.CoreInventory.FindItem(ActiveAmmoDef.AmmoDefinitionId) ?? ActiveAmmoDef.AmmoDef.Const.AmmoItem : ActiveAmmoDef.AmmoDef.Const.AmmoItem;
+                        Comp.CoreInventory.RemoveItems(magItem.ItemId, Reload.MagsLoaded);
+                    }
+                    else if (Comp.CoreInventory.ItemCount > 0 && Comp.CoreInventory.ContainItems(Reload.MagsLoaded, ActiveAmmoDef.AmmoDef.Const.AmmoItem.Content))
+                        Comp.CoreInventory.Remove(ActiveAmmoDef.AmmoDef.Const.AmmoItem, Reload.MagsLoaded);
+                }
                 Reload.CurrentMags = !isPhantom ? Comp.CoreInventory.GetItemAmount(ActiveAmmoDef.AmmoDefinitionId).ToIntSafe() : Reload.CurrentMags - Reload.MagsLoaded;
                 if (Reload.CurrentMags == 0)
                     CheckInventorySystem = true;
             }
+            else
+                Reload.MagsLoaded = ActiveAmmoDef.AmmoDef.Const.MagsToLoad;
 
             StartReload();
             return true;

--- a/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
+++ b/Data/Scripts/CoreSystems/EntityComp/Parts/Weapon/WeaponTracking.cs
@@ -1024,7 +1024,7 @@ namespace CoreSystems.Platform
 
             var targetPos = pTarget?.Position ?? eTarget?.PositionComp.WorldAABB.Center ?? Vector3D.Zero;
             var distToTargetSqr = Vector3D.DistanceSquared(targetPos, trackingCheckPosition);
-            if (distToTargetSqr > MaxTargetDistanceSqr && distToTargetSqr < MinTargetDistanceSqr)
+            if (distToTargetSqr > MaxTargetDistanceSqr || distToTargetSqr < MinTargetDistanceSqr) //TODO this was &&, will that ever trip for a wep with min and max range?
             {
                 masterWeapon.Target.Reset(Session.I.Tick, Target.States.RayCheckDistExceeded);
                 if (masterWeapon != this) Target.Reset(Session.I.Tick, Target.States.RayCheckDistExceeded);
@@ -1042,7 +1042,11 @@ namespace CoreSystems.Platform
                 }
             }
             IHitInfo rayHitInfo;
-            Session.I.Physics.CastRay(trackingCheckPosition, targetPos, out rayHitInfo);
+            if (distToTargetSqr <= 2500)
+                Session.I.Physics.CastRay(trackingCheckPosition, targetPos, out rayHitInfo);
+            else
+                Session.I.Physics.CastLongRay(trackingCheckPosition, targetPos, out rayHitInfo, false); //TODO check if this improves voxel detection
+
             RayCallBack.NormalShootRayCallBack(rayHitInfo);
 
             return true;

--- a/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
+++ b/Data/Scripts/CoreSystems/Projectiles/Projectile.cs
@@ -3399,11 +3399,11 @@ namespace CoreSystems.Projectiles
 
                             var nStorage = netted.Info.Storage;
                             var nAconst = netted.Info.AmmoDef.Const;
-                            if (nStorage.RequestedStage >= 0 && nStorage.RequestedStage < nAconst.ApproachesCount && nAconst.Approaches[nStorage.RequestedStage].IgnoreAntiSmart)
+                            if (nAconst.IgnoreAntiSmarts || (nStorage.RequestedStage >= 0 && nStorage.RequestedStage < nAconst.ApproachesCount && nAconst.Approaches[nStorage.RequestedStage].IgnoreAntiSmart))
                                 continue;
                             if (Info.Random.NextDouble() * 100f < aConst.PulseChance || !aConst.EwarField)
                             {
-                                Info.BaseEwarPool -= (float)netted.Info.AmmoDef.Const.HealthHitModifier;
+                                Info.BaseEwarPool -= (float)nAconst.HealthHitModifier;
                                 if (Info.BaseEwarPool <= 0 && Info.BaseHealthPool-- > 0)
                                 {
                                     Info.EwarActive = true;
@@ -3432,13 +3432,13 @@ namespace CoreSystems.Projectiles
 
                                 var nStorage = netted.Info.Storage;
                                 var nAconst = netted.Info.AmmoDef.Const;
-                                if (nStorage.RequestedStage >= 0 && nStorage.RequestedStage < nAconst.ApproachesCount && nAconst.Approaches[nStorage.RequestedStage].IgnoreAntiSmart)
+                                if (nAconst.IgnoreAntiSmarts || (nStorage.RequestedStage >= 0 && nStorage.RequestedStage < nAconst.ApproachesCount && nAconst.Approaches[nStorage.RequestedStage].IgnoreAntiSmart))
                                     continue;
                                 if (Info.Random.NextDouble() * 100f < aConst.PulseChance || !aConst.EwarField)
                                 {
-                                    if (Info.BaseEwarPool - netted.Info.AmmoDef.Const.Health >= 0)
+                                    if (Info.BaseEwarPool - nAconst.Health >= 0)
                                     {
-                                        Info.BaseEwarPool -= netted.Info.AmmoDef.Const.Health;
+                                        Info.BaseEwarPool -= nAconst.Health;
                                         Info.EwarActive = true;
                                         netted.Info.Target.TargetObject = this;
                                         netted.Info.Target.TargetState = Target.TargetStates.IsProjectile;

--- a/Data/Scripts/CoreSystems/Session/SessionControls.cs
+++ b/Data/Scripts/CoreSystems/Session/SessionControls.cs
@@ -212,25 +212,20 @@ namespace CoreSystems
         }
         internal static void CreateCustomActionSet<T>(Session session) where T : IMyTerminalBlock
         {
+            CreateCustomActions<T>.CreateShootMode(session);
             CreateCustomActions<T>.CreateArmReaction(session);
             CreateCustomActions<T>.CreateTriggerNow(session);
-
-
             CreateCustomActions<T>.CreateKeyShoot(session);
             CreateCustomActions<T>.CreateMouseToggle(session);
-
             CreateCustomActions<T>.CreateShootToggle(session);
             CreateCustomActions<T>.CreateShootOn(session);
             CreateCustomActions<T>.CreateShootOff(session);
-            CreateCustomActions<T>.CreateShootMode(session);
+            CreateCustomActions<T>.CreateAngularTracking(session);
             CreateCustomActions<T>.CreateControlModes(session);
             CreateCustomActions<T>.CreateObjectiveMode(session);
             CreateCustomActions<T>.CreateMovementState(session);
-
             CreateCustomActions<T>.CreateCycleAmmo(session);
             CreateCustomActions<T>.CreateForceReload(session);
-
-            CreateCustomActions<T>.CreateAngularTracking(session);
 
             CreateCustomActions<T>.CreateFocusSubSystem(session);
             CreateCustomActions<T>.CreateSubSystems(session);
@@ -252,42 +247,42 @@ namespace CoreSystems
             CreateCustomActions<T>.CreateWeaponCameraChannels(session);
             CreateCustomActions<T>.CreateSelectFriend(session);
             CreateCustomActions<T>.CreateSelectEnemy(session);
+
             CreateCustomActions<T>.CreateMinSize(session);
             CreateCustomActions<T>.CreateMaxSize(session);
-            CreateCustomActions<T>.CreateFriendly(session);
-            //CreateCustomActions<T>.CreateSelectPosition(session); Suppressed for now as it's inop
+            //CreateCustomActions<T>.CreateFriendly(session);
         }
 
         internal static void CreateTurretControllerActions<T>(Session session) where T : IMyTerminalBlock
         {
             CreateCustomActions<T>.CreateShareFireControlControl(session);
             CreateCustomActions<T>.CreateAiEnabledControl(session);
-            CreateCustomActions<T>.CreateNeutralsControl(session);
-            CreateCustomActions<T>.CreateFriendlyControl(session);
-            CreateCustomActions<T>.CreateUnownedControl(session);
-
-            CreateCustomActions<T>.CreateMovementStateControl(session);
-            //CreateCustomActions<T>.CreateShootModeControl(session);
-            CreateCustomActions<T>.CreateSubSystemsControl(session);
             CreateCustomActions<T>.CreateControlModesControl(session);
-            CreateCustomActions<T>.CreateProjectilesControl(session);
-            CreateCustomActions<T>.CreateSupportingPDControl(session);
-            CreateCustomActions<T>.CreateBiologicalsControl(session);
-            CreateCustomActions<T>.CreateMeteorsControl(session);
-            CreateCustomActions<T>.CreateGridsControl(session);
-            CreateCustomActions<T>.CreateFocusTargetsControl(session);
+            CreateCustomActions<T>.CreateMovementStateControl(session);
             CreateCustomActions<T>.CreateFocusSubSystemControl(session);
-            CreateCustomActions<T>.CreateMaxSizeControl(session);
-            CreateCustomActions<T>.CreateMinSizeControl(session);
+            CreateCustomActions<T>.CreateSubSystemsControl(session);
+
+            CreateCustomActions<T>.CreateFocusTargetsControl(session);
             CreateCustomActions<T>.CreateRepelModeControl(session);
+
+            CreateCustomActions<T>.CreateNeutralsControl(session);
+            CreateCustomActions<T>.CreateUnownedControl(session);
+            CreateCustomActions<T>.CreateGridsControl(session);
             CreateCustomActions<T>.CreateLargeGridControl(session);
             CreateCustomActions<T>.CreateSmallGridControl(session);
+            CreateCustomActions<T>.CreateBiologicalsControl(session);
+            CreateCustomActions<T>.CreateProjectilesControl(session);
+            CreateCustomActions<T>.CreateSupportingPDControl(session);
+            CreateCustomActions<T>.CreateMeteorsControl(session);
+
+            CreateCustomActions<T>.CreateMinSizeControl(session);
+            CreateCustomActions<T>.CreateMaxSizeControl(session);
+            //CreateCustomActions<T>.CreateFriendlyControl(session);
         }
 
         internal static void CreateSearchlightActions<T>(Session session) where T : IMyTerminalBlock
         {
             CreateCustomActions<T>.CreateNeutralsControl(session);
-            //CreateCustomActions<T>.CreateFriendlyControl(session); //This even work for a "turret"?
             CreateCustomActions<T>.CreateUnownedControl(session);
             CreateCustomActions<T>.CreateGridsControl(session);
             CreateCustomActions<T>.CreateLargeGridControl(session);
@@ -295,11 +290,9 @@ namespace CoreSystems
             CreateCustomActions<T>.CreateBiologicalsControl(session);
             CreateCustomActions<T>.CreateProjectilesControl(session);
             CreateCustomActions<T>.CreateMeteorsControl(session);
-
-            CreateCustomActions<T>.CreateMaxSizeControl(session);
-            CreateCustomActions<T>.CreateMinSizeControl(session);
-
             CreateCustomActions<T>.CreateWeaponCameraChannels(session);
+            CreateCustomActions<T>.CreateMinSizeControl(session);
+            CreateCustomActions<T>.CreateMaxSizeControl(session);
         }
 
         internal static void CreateCustomActionSetArmorEnhancer<T>(Session session) where T: IMyTerminalBlock

--- a/Data/Scripts/CoreSystems/Support/Log.cs
+++ b/Data/Scripts/CoreSystems/Support/Log.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using Sandbox.ModAPI;
 using VRage.Collections;
+using VRage.Utils;
 
 namespace CoreSystems.Support
 {
@@ -135,6 +136,7 @@ namespace CoreSystems.Support
             catch (Exception e)
             {
                 MyAPIGateway.Utilities.ShowNotification(e.Message, 5000);
+                MyLog.Default.Error($"WC failed to initialize log {name} \n {e.Message}");
             }
         }
 


### PR DESCRIPTION
- Added option in Smarts to "IgnoreAntiSmarts"
- Fixed Energy ammo reloading, mags to load was ignored but is now factored in to the amount of energy ammo that is "loaded" per reload event
- Fixed corner case of virtual beam updated throwing an exception if the firing grid was deleted while hit checks were waiting on a thread.